### PR TITLE
chore: Upgrade dependencies + investigate async cancellation issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,6 +331,7 @@ dependencies = [
  "send_wrapper",
  "slab",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,6 +550,8 @@ dependencies = [
  "eyre",
  "fluke-buffet",
  "httpwg",
+ "lexopt",
+ "libc",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -677,10 +679,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "libc"
-version = "0.2.153"
+name = "lexopt"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "baff4b617f7df3d896f97fe922b64817f6cd9a756bb81d40f8883f2f66dcb401"
+
+[[package]]
+name = "libc"
+version = "0.2.155"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "lock_api"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,15 +28,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -73,9 +73,9 @@ checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "bytemuck"
-version = "1.15.0"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
+checksum = "102087e286b4677862ea56cf8fc58bb2cdfa8725c40ffb80fe3a008eb7f2fc83"
 
 [[package]]
 name = "byteorder"
@@ -85,9 +85,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cargo-husky"
@@ -97,9 +97,9 @@ checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "504bdec147f2cc13c8b57ed9401fd8a147cc66b67ad5cb241394244f2c947549"
 
 [[package]]
 name = "cfg-if"
@@ -168,22 +168,22 @@ dependencies = [
 
 [[package]]
 name = "enumflags2"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3278c9d5fb675e0a51dabcf4c0d355f692b064171535ba72361be1528a9d8e8d"
+checksum = "d232db7f5956f3f14313dc2f87985c58bd2c695ce124c8cdd984e08e15ac133d"
 dependencies = [
  "enumflags2_derive",
 ]
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
+checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -414,7 +414,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -449,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -517,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -575,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -614,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9febecd4aebbe9c7c23c8e536e966805fdf09944c8a915e7991ee51acb67087"
+checksum = "595a0399f411a508feb2ec1e970a4a30c249351e30208960d58298de8660b0e5"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
@@ -624,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
@@ -675,9 +675,9 @@ checksum = "095b1fc8d841c3df8c3f2db78b7425cb2ec424568a282cb589a880b99d256e84"
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lexopt"
@@ -693,9 +693,9 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -703,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "matchers"
@@ -718,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"
@@ -748,22 +748,23 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
 dependencies = [
+ "hermit-abi",
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -817,16 +818,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "num_enum"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,7 +835,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -876,9 +867,9 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -886,15 +877,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -908,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -951,18 +942,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -981,23 +972,23 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -1011,13 +1002,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -1028,9 +1019,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "ring"
@@ -1059,20 +1050,20 @@ dependencies = [
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustls"
-version = "0.23.5"
+version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afabcee0551bd1aa3e18e5adbf2c0544722014b899adb31bd186ec638d3da97e"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
  "once_cell",
  "ring 0.17.8",
@@ -1084,15 +1075,15 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.4.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.2"
+version = "0.102.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
 dependencies = [
  "ring 0.17.8",
  "rustls-pki-types",
@@ -1101,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "scopeguard"
@@ -1119,31 +1110,32 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.206"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "5b3e4cd94123dd520a128bcd11e34d9e9e423e7e3e50425cb1b4b1e3549d0284"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.206"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "fabfb6138d2383ea8208cf98ccf69cdfb1aff4088460681d84189aa259762f97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -1159,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -1177,18 +1169,18 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1205,9 +1197,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1222,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1233,22 +1225,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.60"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.60"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1282,32 +1274,31 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1373,7 +1364,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1491,7 +1482,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.72",
  "wasm-bindgen-shared",
 ]
 
@@ -1513,7 +1504,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1558,135 +1549,76 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.52.4"
+name = "windows_i686_gnullvm"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
@@ -1714,6 +1646,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bumpalo"
@@ -109,9 +109,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "color-eyre"
@@ -245,7 +245,7 @@ dependencies = [
  "libc",
  "memchr",
  "memmap2",
- "nix 0.28.0",
+ "nix 0.29.0",
  "nom",
  "pretty-hex",
  "pretty_assertions",
@@ -773,7 +773,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if",
  "libc",
  "memoffset",
@@ -781,11 +781,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -976,7 +976,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ members = ["crates/*"]
 [profile.dev.package."*"]
 opt-level = 2
 
+[profile.release]
+debug = 1
+
 [profile.ci]
 inherits = "dev"
 opt-level = 1

--- a/Justfile
+++ b/Justfile
@@ -51,6 +51,6 @@ httpwg-over-tcp *args:
         --package fluke-httpwg-server \
         --package httpwg-cli
     ./target/release/httpwg \
-        --address localhost:8000 \
+        --address localhost:8001 \
         {{args}} \
         -- ./target/release/fluke-httpwg-server

--- a/Justfile
+++ b/Justfile
@@ -4,8 +4,7 @@ _default:
 	just --list
 
 # Run all tests with nextest and cargo-llvm-cov
-ci-test:
-    #!/bin/bash -eux
+ci-test: #!/bin/bash -eux
     just build-testbed
     just cov
     just httpwg-over-tcp
@@ -47,10 +46,11 @@ tls-sample:
 httpwg-gen:
     cargo run --release --package httpwg-gen
 
-httpwg-over-tcp:
+httpwg-over-tcp *args:
     cargo build --release \
         --package fluke-httpwg-server \
         --package httpwg-cli
     ./target/release/httpwg \
         --address localhost:8000 \
+        {{args}} \
         -- ./target/release/fluke-httpwg-server

--- a/Justfile
+++ b/Justfile
@@ -8,6 +8,7 @@ ci-test:
     #!/bin/bash -eux
     just build-testbed
     just cov
+    just httpwg-over-tcp
 
 cov:
     #!/bin/bash -eux
@@ -45,3 +46,11 @@ tls-sample:
 
 httpwg-gen:
     cargo run --release --package httpwg-gen
+
+httpwg-over-tcp:
+    cargo build --release \
+        --package fluke-httpwg-server \
+        --package httpwg-cli
+    ./target/release/httpwg \
+        --address localhost:8000 \
+        -- ./target/release/fluke-httpwg-server

--- a/crates/fluke-buffet/Cargo.toml
+++ b/crates/fluke-buffet/Cargo.toml
@@ -20,18 +20,18 @@ uring = ["dep:io-uring", "dep:fluke-io-uring-async"]
 miri = []
 
 [dependencies]
-bytemuck = { version = "1.15.0", features = ["extern_crate_std"] }
+bytemuck = { version = "1.16.3", features = ["extern_crate_std"] }
 eyre = "0.6.12"
 http = "1.1.0"
-libc = "0.2.153"
-memchr = "2.7.1"
+libc = "0.2.155"
+memchr = "2.7.4"
 memmap2 = { version = "0.9.4", default-features = false }
 nom = "7.1.3"
 pretty-hex = "0.4.1"
 send_wrapper = "0.6.0"
-socket2 = "0.5.6"
-thiserror = { version = "1.0.58", default-features = false }
-tokio = { version = "1.36.0", features = [
+socket2 = "0.5.7"
+thiserror = { version = "1.0.63", default-features = false }
+tokio = { version = "1.39.2", features = [
     "sync",
     "macros",
     "rt",
@@ -44,7 +44,7 @@ nix = "0.28.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 fluke-io-uring-async = { path = "../fluke-io-uring-async", version = "0.1.0", optional = true }
-io-uring = { version = "0.6.3", optional = true }
+io-uring = { version = "0.6.4", optional = true }
 
 [dev-dependencies]
 color-eyre = "0.6.3"

--- a/crates/fluke-buffet/Cargo.toml
+++ b/crates/fluke-buffet/Cargo.toml
@@ -40,7 +40,7 @@ tokio = { version = "1.39.2", features = [
     "time",
 ] }
 tracing = "0.1.40"
-nix = "0.28.0"
+nix = "0.29.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 fluke-io-uring-async = { path = "../fluke-io-uring-async", version = "0.1.0", optional = true }

--- a/crates/fluke-buffet/src/lib.rs
+++ b/crates/fluke-buffet/src/lib.rs
@@ -53,10 +53,13 @@ pub fn start<F: Future>(task: F) -> F::Output {
         lset.spawn_local(IoUringAsync::listen(get_ring()));
 
         let res = lset.run_until(task).await;
+        tracing::debug!("waiting for local set (cancellations, cleanups etc.)");
         // let cleanup_timeout = std::time::Duration::from_millis(250);
-        let cleanup_timeout = std::time::Duration::from_secs(3);
+        let cleanup_timeout = std::time::Duration::from_secs(1);
         if (tokio::time::timeout(cleanup_timeout, lset).await).is_err() {
-            eprintln!("🥲 timed out waiting for local set (async cancellations, cleanups etc.)");
+            tracing::debug!(
+                "🥲 timed out waiting for local set (async cancellations, cleanups etc.)"
+            );
         }
         res
     });

--- a/crates/fluke-buffet/src/lib.rs
+++ b/crates/fluke-buffet/src/lib.rs
@@ -20,7 +20,8 @@ mod uring;
 #[cfg(all(target_os = "linux", feature = "uring"))]
 pub use uring::get_ring;
 
-/// Spawns a new asynchronous task, returning a [tokio::task::JoinHandle] for it.
+/// Spawns a new asynchronous task, returning a [tokio::task::JoinHandle] for
+/// it.
 ///
 /// Spawning a task enables the task to execute concurrently to other tasks.
 /// There is no guarantee that a spawned task will execute to completion. When a
@@ -48,12 +49,14 @@ pub fn start<F: Future>(task: F) -> F::Output {
         .build()
         .unwrap();
     let res = rt.block_on(async move {
-        let local = LocalSet::new();
-        local.spawn_local(IoUringAsync::listen(get_ring()));
+        let lset = LocalSet::new();
+        lset.spawn_local(IoUringAsync::listen(get_ring()));
 
-        let res = local.run_until(task).await;
-        if (tokio::time::timeout(std::time::Duration::from_millis(250), local).await).is_err() {
-            eprintln!("timed out waiting for local set");
+        let res = lset.run_until(task).await;
+        // let cleanup_timeout = std::time::Duration::from_millis(250);
+        let cleanup_timeout = std::time::Duration::from_secs(3);
+        if (tokio::time::timeout(cleanup_timeout, lset).await).is_err() {
+            eprintln!("🥲 timed out waiting for local set (async cancellations, cleanups etc.)");
         }
         res
     });

--- a/crates/fluke-buffet/src/net/net_uring.rs
+++ b/crates/fluke-buffet/src/net/net_uring.rs
@@ -151,6 +151,7 @@ impl WriteOwned for TcpWriteHalf {
     // TODO: implement writev
 
     async fn shutdown(&mut self) -> std::io::Result<()> {
+        tracing::debug!("requesting shutdown");
         let sqe =
             io_uring::opcode::Shutdown::new(io_uring::types::Fd(self.0.fd), libc::SHUT_WR).build();
         let cqe = get_ring().push(sqe).await;

--- a/crates/fluke-curl-tests/Cargo.toml
+++ b/crates/fluke-curl-tests/Cargo.toml
@@ -10,18 +10,18 @@ publish = false
 
 [dev-dependencies]
 fluke = { version = "0.1.1", path = "../../crates/fluke" }
-bytes = { version = "1.5.0", default-features = false }
+bytes = { version = "1.7.1", default-features = false }
 pretty_assertions = { version = "1.4.0", default-features = false, features = [
     "std",
 ] }
-tokio-stream = { version = "0.1.14", default-features = false }
+tokio-stream = { version = "0.1.15", default-features = false }
 tracing-subscriber = { version = "0.3.18", default-features = false, features = [
     "std",
     "fmt",
     "ansi",
 ] }
-httparse = { version = "1.8.0", default-features = false, features = ["std"] }
-tokio = { version = "1.36.0", default-features = false, features = [
+httparse = { version = "1.9.4", default-features = false, features = ["std"] }
+tokio = { version = "1.39.2", default-features = false, features = [
     "io-util",
     "process",
     "time",
@@ -29,7 +29,7 @@ tokio = { version = "1.36.0", default-features = false, features = [
 futures-util = { version = "0.3.30", default-features = false, features = [
     "std",
 ] }
-libc = "0.2.153"
+libc = "0.2.155"
 eyre = { version = "0.6.12", default-features = false }
 tracing = "0.1.40"
 http = "1.1.0"

--- a/crates/fluke-h2-parse/Cargo.toml
+++ b/crates/fluke-h2-parse/Cargo.toml
@@ -13,9 +13,9 @@ rust-version = "1.75"
 
 [dependencies]
 enum-repr = "0.2.6"
-enumflags2 = "0.7.9"
+enumflags2 = "0.7.10"
 nom = { version = "7.1.3", default-features = false }
 fluke-buffet = { version = "0.2.0", path = "../fluke-buffet" }
-thiserror = "1.0.60"
+thiserror = "1.0.63"
 byteorder = "1.5.0"
 tracing = "0.1.40"

--- a/crates/fluke-h2-parse/src/lib.rs
+++ b/crates/fluke-h2-parse/src/lib.rs
@@ -404,9 +404,9 @@ impl Frame {
 }
 
 impl IntoPiece for Frame {
-    fn into_piece(self, mut scratch: &mut RollMut) -> std::io::Result<Piece> {
+    fn into_piece(self, scratch: &mut RollMut) -> std::io::Result<Piece> {
         debug_assert_eq!(scratch.len(), 0);
-        self.write_into(&mut scratch)?;
+        self.write_into(&mut *scratch)?;
         Ok(scratch.take_all().into())
     }
 }

--- a/crates/fluke-hpack/Cargo.toml
+++ b/crates/fluke-hpack/Cargo.toml
@@ -21,11 +21,11 @@ documentation = "https://docs.rs/fluke-hpack"
 interop-tests = []
 
 [dev-dependencies]
-serde = { version = "1.0.197", features = ["derive"] }
-serde_json = "1.0.114"
+serde = { version = "1.0.206", features = ["derive"] }
+serde_json = "1.0.122"
 hex = "0.4.3"
-thiserror = "1.0.58"
+thiserror = "1.0.63"
 
 [dependencies]
-thiserror = "1.0.58"
+thiserror = "1.0.63"
 tracing = "0.1"

--- a/crates/fluke-httpwg-server/src/main.rs
+++ b/crates/fluke-httpwg-server/src/main.rs
@@ -13,7 +13,7 @@ fn main() {
     setup_tracing_and_error_reporting();
 
     fluke_buffet::start(async move {
-        let ln = fluke_buffet::net::TcpListener::bind("127.0.0.1:8000".parse().unwrap())
+        let ln = fluke_buffet::net::TcpListener::bind("127.0.0.1:8001".parse().unwrap())
             .await
             .unwrap();
 

--- a/crates/fluke-hyper-testbed/Cargo.toml
+++ b/crates/fluke-hyper-testbed/Cargo.toml
@@ -5,15 +5,15 @@ edition = "2021"
 publish = false
 
 [dependencies]
-bytes = "1.5.0"
+bytes = "1.7.1"
 futures = "0.3.30"
-hyper = { version = "0.14.28", features = [
+hyper = { version = "0.14.30", features = [
     "client",
     "server",
     "http1",
     "tcp",
     "stream",
 ] }
-tokio = { version = "1.36.0", features = ["full"] }
-tokio-stream = "0.1.14"
+tokio = { version = "1.39.2", features = ["full"] }
+tokio-stream = "0.1.15"
 tracing = "0.1.40"

--- a/crates/fluke-io-uring-async/Cargo.toml
+++ b/crates/fluke-io-uring-async/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.75"
 [dependencies]
 tokio = { version = "1.2", features = ["rt", "net"] }
 slab = { version = "0.4" }
+tracing = "0.1.40"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = { version = "0.6.3" }

--- a/crates/fluke-io-uring-async/Cargo.toml
+++ b/crates/fluke-io-uring-async/Cargo.toml
@@ -14,12 +14,12 @@ rust-version = "1.75"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.2", features = ["rt", "net"] }
+tokio = { version = "1.39", features = ["rt", "net"] }
 slab = { version = "0.4" }
 tracing = "0.1.40"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-io-uring = { version = "0.6.3" }
+io-uring = { version = "0.6.4" }
 
 [dev-dependencies]
 send_wrapper = { version = "0.6.0" }

--- a/crates/fluke-io-uring-async/src/linux.rs
+++ b/crates/fluke-io-uring-async/src/linux.rs
@@ -90,6 +90,23 @@ impl<C: cqueue::Entry> Drop for Op<C> {
                 std::mem::forget(cancel_op);
                 tracing::debug!("doing async cancel for op {index} (cancel_fut forgotten)");
 
+                struct NoisyDrop;
+
+                impl Drop for NoisyDrop {
+                    fn drop(&mut self) {
+                        tracing::debug!("dropping noisy drop");
+                    }
+                }
+
+                let noisy_drop = NoisyDrop;
+                tracing::debug!("spawning noisy drop task");
+                tokio::task::spawn_local(async move {
+                    tracing::debug!("inside noisy drop spawned task");
+                    drop(noisy_drop);
+                    tracing::debug!("inside noisy drop spawned task.. dropped!");
+                });
+                tracing::debug!("spawned noisy drop task");
+
                 tokio::task::spawn_local(async move {
                     tracing::debug!("cancelling op {index}");
                     cancel_op_inner.await;

--- a/crates/fluke-tls-sample/Cargo.toml
+++ b/crates/fluke-tls-sample/Cargo.toml
@@ -6,17 +6,17 @@ description = "A sample HTTPS proxy using fluke"
 publish = false
 
 [dependencies]
-color-eyre = "0.6.2"
+color-eyre = "0.6.3"
 fluke = { path = "../../crates/fluke" }
 rcgen = "0.10.0"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-rustls = { version = "0.23.5", default-features = false }
-tokio = { version = "1.36.0", features = ["full"] }
+rustls = { version = "0.23.12", default-features = false }
+tokio = { version = "1.39.2", features = ["full"] }
 tokio-rustls = { git = "https://github.com/rustls/tokio-rustls", rev = "caf4e8267f0e708a2bfc561dec98a842dc960ba6", default-features = false }
 http = "1.1.0"
 pretty-hex = "0.4.1"
-socket2 = "0.5.6"
+socket2 = "0.5.7"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # branch rustls-0.23

--- a/crates/fluke/Cargo.toml
+++ b/crates/fluke/Cargo.toml
@@ -24,22 +24,22 @@ futures-util = "0.3.30"
 fluke-buffet = { version = "0.2.0", path = "../fluke-buffet" }
 fluke-hpack = { version = "0.3.1", path = "../fluke-hpack" }
 http = "1.1.0"
-memchr = "2.7.1"
+memchr = "2.7.4"
 nom = { version = "7.1.3", default-features = false }
 pretty-hex = { version = "0.4.1", default-features = false }
-smallvec = { version = "1.13.1", default-features = false, features = [
+smallvec = { version = "1.13.2", default-features = false, features = [
     "const_generics",
     "const_new",
     "union",
 ] }
-thiserror = { version = "1.0.58", default-features = false }
-tokio = { version = "1.36.0", features = ["macros", "sync"] }
+thiserror = { version = "1.0.63", default-features = false }
+tokio = { version = "1.39.2", features = ["macros", "sync"] }
 tracing = { version = "0.1.40", default-features = false }
 fluke-h2-parse = { version = "0.1.1", path = "../fluke-h2-parse" }
 
 [dev-dependencies]
 fluke-buffet = { version = "0.2.0", path = "../fluke-buffet" }
-bytes = { version = "1.5.0", default-features = false }
+bytes = { version = "1.7.1", default-features = false }
 pretty_assertions = { version = "1.4.0", default-features = false, features = [
     "std",
 ] }
@@ -49,8 +49,8 @@ tracing-subscriber = { version = "0.3.18", default-features = false, features = 
     "fmt",
     "ansi",
 ] }
-httparse = { version = "1.8.0", default-features = false, features = ["std"] }
-tokio = { version = "1.36.0", default-features = false, features = [
+httparse = { version = "1.9.4", default-features = false, features = ["std"] }
+tokio = { version = "1.39.2", default-features = false, features = [
     "io-util",
     "process",
     "time",
@@ -58,7 +58,7 @@ tokio = { version = "1.36.0", default-features = false, features = [
 futures-util = { version = "0.3.30", default-features = false, features = [
     "std",
 ] }
-libc = "0.2.153"
+libc = "0.2.155"
 httpwg = { path = "../httpwg" }
 color-eyre = "0.6.3"
 httpwg-macros = { path = "../httpwg-macros" }

--- a/crates/fluke/tests/httpwg2.rs
+++ b/crates/fluke/tests/httpwg2.rs
@@ -27,8 +27,7 @@ pub(crate) fn setup_tracing_and_error_reporting() {
     let fmt_layer = tracing_subscriber::fmt::layer()
         .with_ansi(true)
         .with_file(false)
-        .with_line_number(false)
-        .without_time();
+        .with_line_number(false);
 
     tracing_subscriber::registry()
         .with(targets)

--- a/crates/httpwg-cli/Cargo.toml
+++ b/crates/httpwg-cli/Cargo.toml
@@ -3,11 +3,17 @@ name = "httpwg-cli"
 version = "0.1.0"
 edition = "2021"
 
+[[bin]]
+name = "httpwg"
+path = "src/main.rs"
+
 [dependencies]
 color-eyre = "0.6.3"
 eyre = "0.6.12"
 fluke-buffet = { version = "0.2.0", path = "../fluke-buffet" }
 httpwg = { version = "0.1.1", path = "../httpwg" }
+lexopt = "0.3.0"
+libc = "0.2.155"
 tokio = { version = "1.38.0", features = ["time"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18" }

--- a/crates/httpwg-cli/Cargo.toml
+++ b/crates/httpwg-cli/Cargo.toml
@@ -14,6 +14,6 @@ fluke-buffet = { version = "0.2.0", path = "../fluke-buffet" }
 httpwg = { version = "0.1.1", path = "../httpwg" }
 lexopt = "0.3.0"
 libc = "0.2.155"
-tokio = { version = "1.38.0", features = ["time"] }
+tokio = { version = "1.39.2", features = ["time"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18" }

--- a/crates/httpwg-cli/src/main.rs
+++ b/crates/httpwg-cli/src/main.rs
@@ -1,5 +1,6 @@
 use std::{
-    collections::HashMap, future::Future, net::SocketAddr, pin::Pin, rc::Rc, time::Duration,
+    collections::HashMap, ffi::OsString, future::Future, net::SocketAddr, pin::Pin, rc::Rc,
+    time::Duration,
 };
 
 use fluke_buffet::{net::TcpStream, IntoHalves};
@@ -7,54 +8,215 @@ use httpwg::{rfc9113, Config, Conn};
 use tracing::Level;
 use tracing_subscriber::{filter::Targets, layer::SubscriberExt, util::SubscriberInitExt};
 
-fn main() {
-    setup_tracing_and_error_reporting();
+#[derive(Default, Debug)]
+struct Args {
+    /// the binary to run tests against (and any args to pass to it)
+    server_binary: Vec<String>,
 
+    /// the address/port the binary will listen on
+    server_address: Option<SocketAddr>,
+
+    /// the timeout for connections (in milliseconds)
+    connect_timeout: Option<u64>,
+
+    /// which tests to run
+    filter: Option<String>,
+}
+
+pub trait IntoStringResult {
+    fn into_string_result(self) -> eyre::Result<String>;
+}
+
+impl IntoStringResult for OsString {
+    fn into_string_result(self) -> eyre::Result<String> {
+        self.into_string()
+            .map_err(|_| eyre::eyre!("OsString contained invalid UTF-8"))
+    }
+}
+
+fn parse_args() -> eyre::Result<Args> {
+    let mut args: Args = Default::default();
+    let mut parser = lexopt::Parser::from_env();
+    while let Some(arg) = parser.next().unwrap() {
+        match arg {
+            lexopt::Arg::Long("address") | lexopt::Arg::Short('a') => {
+                let value = parser.value()?.into_string_result()?;
+                args.server_address = Some(match value.parse() {
+                    Ok(addr) => addr,
+                    Err(_) => {
+                        use std::net::ToSocketAddrs;
+                        let addrs: Vec<_> = value.to_socket_addrs()?.collect();
+                        addrs
+                            .iter()
+                            // prefer IPv4 addresses but we'll take what we can get
+                            .find(|addr| addr.is_ipv4())
+                            .or_else(|| addrs.first())
+                            .cloned()
+                            .ok_or_else(|| {
+                                eyre::eyre!("Failed to parse/resolve address: {}", value)
+                            })?
+                    }
+                });
+            }
+            lexopt::Arg::Long("connect-timeout") | lexopt::Arg::Short('t') => {
+                args.connect_timeout = Some(
+                    parser
+                        .value()?
+                        .into_string_result()?
+                        .parse()
+                        .map_err(|e| eyre::eyre!("Failed to parse connect timeout: {}", e))?,
+                );
+            }
+            lexopt::Arg::Long("filter") | lexopt::Arg::Short('f') => {
+                args.filter = Some(parser.value()?.into_string_result()?);
+            }
+            lexopt::Arg::Value(value) => {
+                args.server_binary.push(value.into_string_result()?);
+            }
+            _ => return Err(arg.unexpected().into()),
+        }
+    }
+    Ok(args)
+}
+
+fn print_usage() -> eyre::Result<()> {
+    eprintln!(
+        "Usage: httpwg-test-suite [OPTIONS] [-- SERVER [ARGS]]
+
+Options:
+    -a, --address <ADDRESS>    The address/port the server will listen on
+    -t, --connect-timeout <MS> The timeout for connections in milliseconds
+    -f, --filter <FILTER>      Which tests to run
+
+Arguments:
+    SERVER                     The server to run tests against
+    [ARGS]                     Any additional arguments to pass to the server
+
+Examples:
+    httpwg-test-suite -a 127.0.0.1:8080 -- ./my_server
+    httpwg-test-suite -f 'RFC 9113' -- ./my_server --go-fast
+"
+    );
+    Ok(())
+}
+
+fn main() -> eyre::Result<()> {
+    let args = match parse_args() {
+        Ok(args) => args,
+        Err(e) => {
+            eprintln!("Failed to parse arguments: {}", e);
+
+            print_usage()?;
+            return Ok(());
+        }
+    };
+    setup_tracing_and_error_reporting();
+    fluke_buffet::start(async move { async_main(args).await })?;
+
+    Ok(())
+}
+
+async fn async_main(args: Args) -> eyre::Result<()> {
     let cat = catalog::<fluke_buffet::net::TcpStream>();
 
-    // filter is set to the first argument, if there is a first argument
-    let filter = std::env::args().nth(1);
+    let addr = match args.server_address {
+        Some(addr) => addr,
+        None => {
+            eprintln!("No address specified");
+            print_usage()?;
+            std::process::exit(1);
+        }
+    };
+    let connect_timeout = match args.connect_timeout {
+        Some(timeout) => Duration::from_millis(timeout),
+        None => Duration::from_millis(250),
+    };
+    let conf = Rc::new(Config {
+        timeout: connect_timeout,
+        ..Default::default()
+    });
 
-    fluke_buffet::start(async move {
-        // now run it! establish a new TCP connection for every case, and run the test.
-        let addr = "localhost:8000";
-        let conf = Rc::new(Config {
-            timeout: Duration::from_secs(3),
-            ..Default::default()
-        });
+    eprintln!("Will run tests against {addr} with a connect timeout of {connect_timeout:?}");
+    if !args.server_binary.is_empty() {
+        let binary_and_args = args.server_binary;
 
-        let local_set = tokio::task::LocalSet::new();
-
-        for (rfc, sections) in cat {
-            for (section, tests) in sections {
-                for (test, boxed_test) in tests {
-                    let test_name = format!("{rfc} :: {section} :: {test}");
-                    if let Some(filter) = &filter {
-                        if !test_name.contains(filter) {
-                            println!("Skipping test: {}", test_name);
-                            continue;
-                        }
-                    }
-
-                    let addr: SocketAddr = addr.parse().unwrap();
-                    let stream =
-                        tokio::time::timeout(Duration::from_millis(250), TcpStream::connect(addr))
-                            .await
-                            .unwrap()
-                            .unwrap();
-                    let conn = Conn::new(conf.clone(), stream);
-                    let test = async move {
-                        println!("🔷 Running test: {}", test_name);
-                        boxed_test(conn).await.unwrap();
-                        println!("✅ Test passed: {}", test_name);
-                    };
-                    local_set.spawn_local(test);
+        eprintln!(
+            "Launching ({}) now and waiting until it listens on {addr}",
+            binary_and_args.join(" ::: ")
+        );
+        let mut iter = binary_and_args.into_iter();
+        let mut cmd = std::process::Command::new(iter.next().unwrap());
+        for arg in iter {
+            cmd.arg(arg);
+        }
+        #[cfg(unix)]
+        unsafe {
+            // avoid zombie children on unix: no matter how the test runner dies,
+            // the server will die with it.
+            use std::os::unix::process::CommandExt;
+            cmd.pre_exec(|| {
+                let ret = libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM);
+                if ret != 0 {
+                    panic!("prctl failed");
                 }
+                Ok(())
+            });
+        }
+        let mut child = cmd.spawn().expect("Failed to launch server");
+        eprintln!("Server started");
+        std::thread::spawn(move || {
+            let status = child.wait().unwrap();
+            eprintln!("Server exited with status: {status:?}");
+        });
+    } else {
+        eprintln!("No server binary specified");
+    };
+
+    eprintln!("Waiting until server is listening on {addr}");
+    let start = std::time::Instant::now();
+    let duration = Duration::from_secs(3);
+    while start.elapsed() < duration {
+        match tokio::time::timeout(Duration::from_millis(100), TcpStream::connect(addr)).await {
+            Ok(Ok(_)) => break,
+            _ => tokio::time::sleep(Duration::from_millis(100)).await,
+        }
+    }
+    if start.elapsed() >= duration {
+        panic!("Server did not start listening within 3 seconds");
+    }
+
+    let local_set = tokio::task::LocalSet::new();
+
+    for (rfc, sections) in cat {
+        for (section, tests) in sections {
+            for (test, boxed_test) in tests {
+                let test_name = format!("{rfc} :: {section} :: {test}");
+                if let Some(filter) = &args.filter {
+                    if !test_name.contains(filter) {
+                        println!("Skipping test: {}", test_name);
+                        continue;
+                    }
+                }
+
+                let stream =
+                    tokio::time::timeout(Duration::from_millis(250), TcpStream::connect(addr))
+                        .await
+                        .unwrap()
+                        .unwrap();
+                let conn = Conn::new(conf.clone(), stream);
+                let test = async move {
+                    println!("🔷 Running test: {}", test_name);
+                    boxed_test(conn).await.unwrap();
+                    println!("✅ Test passed: {}", test_name);
+                };
+                local_set.spawn_local(test);
             }
         }
+    }
 
-        local_set.await;
-    });
+    local_set.await;
+
+    Ok(())
 }
 
 type Catalog<IO> =

--- a/crates/httpwg-cli/src/main.rs
+++ b/crates/httpwg-cli/src/main.rs
@@ -174,7 +174,7 @@ async fn async_main(args: Args) -> eyre::Result<()> {
 
     eprintln!("Waiting until server is listening on {addr}");
     let start = std::time::Instant::now();
-    let duration = Duration::from_secs(3);
+    let duration = Duration::from_secs(1);
     while start.elapsed() < duration {
         match tokio::time::timeout(Duration::from_millis(100), TcpStream::connect(addr)).await {
             Ok(Ok(_)) => break,

--- a/crates/httpwg-gen/Cargo.toml
+++ b/crates/httpwg-gen/Cargo.toml
@@ -6,5 +6,5 @@ description = "Generates httpwg-macros from rustdoc's JSON output"
 publish = false
 
 [dependencies]
-serde = { version = "1.0.197", features = ["derive"] }
-serde_json = "1.0.114"
+serde = { version = "1.0.206", features = ["derive"] }
+serde_json = "1.0.122"

--- a/crates/httpwg-gen/src/ast.rs
+++ b/crates/httpwg-gen/src/ast.rs
@@ -20,6 +20,7 @@ pub struct Document {
 
 #[derive(Deserialize)]
 pub struct Item {
+    #[allow(dead_code)]
     pub id: ItemId,
     pub name: Option<String>,
     pub docs: Option<String>,

--- a/crates/httpwg/Cargo.toml
+++ b/crates/httpwg/Cargo.toml
@@ -12,13 +12,13 @@ Test cases for RFC 9113 (HTTP/2)
 rust-version = "1.75"
 
 [dependencies]
-bytes = "1.5.0"
-enumflags2 = "0.7.9"
+bytes = "1.7.1"
+enumflags2 = "0.7.10"
 eyre = "0.6.12"
 fluke-buffet = { version = "0.2.0", path = "../fluke-buffet" }
 fluke-h2-parse = { version = "0.1.1", path = "../fluke-h2-parse" }
 fluke-hpack = { version = "0.3.1", path = "../fluke-hpack" }
 futures-util = "0.3.30"
 pretty-hex = "0.4.1"
-tokio = { version = "1.37.0", features = ["time"] }
+tokio = { version = "1.39.2", features = ["time"] }
 tracing = "0.1.40"

--- a/crates/httpwg/src/lib.rs
+++ b/crates/httpwg/src/lib.rs
@@ -991,9 +991,7 @@ impl<IO: IntoHalves> Conn<IO> {
         self.verify_stream_error(ErrorC::ProtocolError).await?;
         tracing::debug!("verifying stream error... done!");
 
-        tracing::debug!("requesting shutdown");
-        self.w.shutdown().await?;
-        tracing::debug!("requesting shutdown... done!");
+        // self.w.shutdown().await?;
 
         Ok(())
     }

--- a/crates/httpwg/src/lib.rs
+++ b/crates/httpwg/src/lib.rs
@@ -991,6 +991,10 @@ impl<IO: IntoHalves> Conn<IO> {
         self.verify_stream_error(ErrorC::ProtocolError).await?;
         tracing::debug!("verifying stream error... done!");
 
+        tracing::debug!("requesting shutdown");
+        self.w.shutdown().await?;
+        tracing::debug!("requesting shutdown... done!");
+
         Ok(())
     }
 }

--- a/crates/httpwg/src/rfc9113/_8_expressing_http_semantics_in_http2.rs
+++ b/crates/httpwg/src/rfc9113/_8_expressing_http_semantics_in_http2.rs
@@ -2,7 +2,7 @@
 
 use std::io::Write;
 
-use fluke_buffet::{IntoHalves, WriteOwned};
+use fluke_buffet::IntoHalves;
 use fluke_h2_parse::{pack_bit_and_u31, FrameType, HeadersFlags, StreamId};
 
 use crate::{Conn, ErrorC, FrameT, Headers};
@@ -593,10 +593,6 @@ pub async fn sends_headers_frame_with_empty_path_component<IO: IntoHalves>(
     conn.send_req_and_expect_stream_rst(StreamId(1), &headers)
         .await?;
     tracing::debug!("empty path component test passed!");
-
-    tracing::debug!("requesting shutdown...");
-    conn.w.shutdown().await?;
-    tracing::debug!("requesting shutdown... done!");
 
     Ok(())
 }

--- a/crates/httpwg/src/rfc9113/_8_expressing_http_semantics_in_http2.rs
+++ b/crates/httpwg/src/rfc9113/_8_expressing_http_semantics_in_http2.rs
@@ -2,7 +2,7 @@
 
 use std::io::Write;
 
-use fluke_buffet::IntoHalves;
+use fluke_buffet::{IntoHalves, WriteOwned};
 use fluke_h2_parse::{pack_bit_and_u31, FrameType, HeadersFlags, StreamId};
 
 use crate::{Conn, ErrorC, FrameT, Headers};
@@ -593,6 +593,10 @@ pub async fn sends_headers_frame_with_empty_path_component<IO: IntoHalves>(
     conn.send_req_and_expect_stream_rst(StreamId(1), &headers)
         .await?;
     tracing::debug!("empty path component test passed!");
+
+    tracing::debug!("requesting shutdown...");
+    conn.w.shutdown().await?;
+    tracing::debug!("requesting shutdown... done!");
 
     Ok(())
 }

--- a/crates/httpwg/src/rfc9113/_8_expressing_http_semantics_in_http2.rs
+++ b/crates/httpwg/src/rfc9113/_8_expressing_http_semantics_in_http2.rs
@@ -592,6 +592,7 @@ pub async fn sends_headers_frame_with_empty_path_component<IO: IntoHalves>(
     headers.replace(":path", "");
     conn.send_req_and_expect_stream_rst(StreamId(1), &headers)
         .await?;
+    tracing::debug!("empty path component test passed!");
 
     Ok(())
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.80.1"
 components = ["clippy", "rust-src"]


### PR DESCRIPTION
The main problem of running those is cleanup of async ops: there's a "read HTTP/2 frames" loop in httpwg, and that entire task gets dropped after the test is finished (when shutting down the runtime), which results in `Op drop occured before completion (index 0)` messages):

```shell
amos in 🌐 brat in fluke on  httpwg-cli-p2 [!] via 🦀 v1.80.1 took 4s
❯ RUST_LOG=debug RUST_BACKTRACE=0 just httpwg-over-tcp -t 3000 -f 'path'
cargo build --release --package fluke-httpwg-server --package httpwg-cli
    Blocking waiting for file lock on package cache
   Compiling httpwg v0.1.1 (/home/amos/bearcove/fluke/crates/httpwg)
   Compiling httpwg-cli v0.1.0 (/home/amos/bearcove/fluke/crates/httpwg-cli)
    Finished `release` profile [optimized + debuginfo] target(s) in 1.44s
./target/release/httpwg --address localhost:8001 -t 3000 -f path -- ./target/release/fluke-httpwg-server
Will run tests against 127.0.0.1:8001 with a connect timeout of 3s
Launching (./target/release/fluke-httpwg-server) now and waiting until it listens on 127.0.0.1:8001
Server started
Waiting until server is listening on 127.0.0.1:8001
Listening on 127.0.0.1:8001 for 'http2 prior knowledge' connections (no TLS)
 INFO fluke_httpwg_server: Accepted connection addr=127.0.0.1:33854
Skipping test: RFC 9113 :: Section 8: Expressing HTTP Semantics in HTTP/2 :: sends connect with scheme
Skipping test: RFC 9113 :: Section 8: Expressing HTTP Semantics in HTTP/2 :: client sends push promise frame
🔷 Running test: RFC 9113 :: Section 8: Expressing HTTP Semantics in HTTP/2 :: sends connect with path
DEBUG fluke::h2::server: h2 client closed connection before sending preface
DEBUG fluke::h2::server: finished serving
DEBUG fluke_httpwg_server: http/2 server done
 INFO fluke_httpwg_server: Accepted connection addr=127.0.0.1:33866
DEBUG fluke::h2::server: Sending initial settings
DEBUG fluke::h2::server: > frame=Conn:Settings { len: 36 }
DEBUG fluke::h2::server: Starting both deframe & process tasks
DEBUG fluke::h2::server: < frame=Conn:Settings { len: 12 }
DEBUG httpwg: < Conn:Settings { len: 36 }
DEBUG fluke::h2::server: > frame=Conn:Settings { flags: Ack }
DEBUG fluke::h2::server: < frame=Conn:Settings { flags: Ack }
DEBUG fluke::h2::server: Acknowledged peer settings
DEBUG fluke::h2::server: Peer has acknowledged our settings, cool
DEBUG httpwg: < Conn:Settings { flags: Ack }
DEBUG fluke::h2::server: < frame=#1:Headers { len: 27, flags: EndStream | EndHeaders }
DEBUG httpwg: verifying stream error...
DEBUG httpwg: waiting for frame GoAaway | RstStream
DEBUG fluke::h2::server: Receiving headers stream_id=1 last_stream_id=0 next_stream_count=1
DEBUG fluke::h2::server: Headers | :method: CONNECT
DEBUG fluke::h2::server: Headers | :path: /
DEBUG fluke::h2::server: Headers | :authority: example.com:443
DEBUG fluke::h2::server: Sending rst because: bad request: CONNECT method MUST NOT include ':path' pseudo-header (known error code: ProtocolError)
DEBUG fluke::h2::server: Sending RstStream stream_id=1 error_code=ProtocolError
DEBUG fluke::h2::server: > frame=#1:RstStream { len: 4 }
DEBUG httpwg: < #1:RstStream { len: 4 }
DEBUG httpwg: waiting for frame GoAaway | RstStream.. got an outcome
DEBUG httpwg: waiting for frame GoAaway | RstStream.. got RstStream
DEBUG httpwg: verifying stream error... done!
✅ Test passed: RFC 9113 :: Section 8: Expressing HTTP Semantics in HTTP/2 :: sends connect with path
DEBUG httpwg: timed out reading frame header
The application panicked (crashed).
Message:  Op drop occured before completion (index 0)
Location: /home/amos/bearcove/fluke/crates/fluke-io-uring-async/src/linux.rs:123

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
🥲 timed out waiting for local set (async cancellations, cleanups etc.)
DEBUG fluke::h2::server: Peer hung up
DEBUG fluke::h2::server: h2 deframe task finished res=Ok(())
DEBUG fluke::h2::server: h2 process task: peer hung up
DEBUG fluke::h2::server: finished serving
DEBUG fluke_httpwg_server: http/2 server done
```

Even when explicitly shutting down the write end of the connection, we still time out waiting for the local set — I'm not sure what's spawned there that is stuck, maybe it's the "async op canceller" I've tried to implement here?

https://github.com/bearcove/fluke/blob/73b5116d18e1516c17d679bd575c6b8a019f09ab/crates/fluke-io-uring-async/src/linux.rs#L70-L79

Not sure. I don't have a lot of time to look into this today, so anyone's eyeballs/investigation/expertise is very welcome as deadlines loom closer.