### PR TITLE
chore: More async cancellation cleanups

### DIFF
--- a/crates/httpwg-cli/src/main.rs
+++ b/crates/httpwg-cli/src/main.rs
@@ -209,7 +209,11 @@ async fn async_main(args: Args) -> eyre::Result<()> {
                     boxed_test(conn).await.unwrap();
                     println!("✅ Test passed: {}", test_name);
                 };
-                local_set.spawn_local(test);
+                local_set.spawn_local(async move {
+                    {
+                        test.await;
+                    }
+                });
             }
         }
     }


### PR DESCRIPTION
This cancels the `IoUringAsync::listen` task in fluke-buffet before waiting for the LocalSet to finish.

That's a clean-up follow-up to #198 